### PR TITLE
Update setup-vs-requirement URL

### DIFF
--- a/application-dependencies.html
+++ b/application-dependencies.html
@@ -128,7 +128,7 @@ so a dependency manager can correctly install both the library as well as
 additional dependencies for the library. There's still quite a bit of 
 confusion in the Python community over the difference between 
 requirements.txt and setup.py, so read this 
-<a href="https://caremad.io/blog/setup-vs-requirement/">well written post</a> for
+<a href="https://caremad.io/2013/07/setup-vs-requirement/">well written post</a> for
 further clarification.</p>
 <h2>Application dependency resources</h2>
 <ul>


### PR DESCRIPTION
The URL structure for the \<a href=""\> link has changed, which was causing the link to point at a page that didn't exist anymore. Updated with the new link.